### PR TITLE
fix(dashboard): Display username in dashboard owner's filter and dashboard access field

### DIFF
--- a/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
@@ -159,18 +159,10 @@ const PropertiesModal = ({
           .filter((item: { extra: { active: boolean } }) =>
             item.extra.active !== undefined ? item.extra.active : true,
           )
-          .map(
-            (item: {
-              value: number;
-              text: string;
-              extra: { username: string };
-            }) => ({
-              value: item.value,
-              label: item.extra?.username
-                ? `${item.text} (${item.extra.username})`
-                : item.text,
-            }),
-          ),
+          .map((item: { value: number; text: string }) => ({
+            value: item.value,
+            label: item.text,
+          })),
         totalCount: response.json.count,
       }));
     },

--- a/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
@@ -164,10 +164,18 @@ const PropertiesModal = ({
           .filter((item: { extra: { active: boolean } }) =>
             item.extra.active !== undefined ? item.extra.active : true,
           )
-          .map((item: { value: number; text: string }) => ({
-            value: item.value,
-            label: item.text,
-          })),
+          .map(
+            (item: {
+              value: number;
+              text: string;
+              extra: { username: string };
+            }) => ({
+              value: item.value,
+              label: item.extra?.username
+                ? `${item.text} (${item.extra.username})`
+                : item.text,
+            }),
+          ),
         totalCount: response.json.count,
       }));
     },

--- a/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
@@ -50,7 +50,7 @@ import {
   UserWithPermissionsAndRoles,
 } from 'src/types/bootstrapTypes';
 import { applyColors, getColorNamespace } from 'src/utils/colorScheme';
-import getOwnerName from 'src/utils/getOwnerName';
+import { getOwnerDisplayName } from 'src/utils/getOwnerName';
 import Owner from 'src/types/Owner';
 
 const StyledFormItem = styled(FormItem)`
@@ -77,12 +77,7 @@ type PropertiesModalProps = {
 };
 
 type Roles = { id: number; name: string }[];
-type Owners = {
-  id: number;
-  full_name?: string;
-  first_name?: string;
-  last_name?: string;
-}[];
+type Owners = Owner[];
 type DashboardInfo = {
   id: number;
   title: string;
@@ -274,7 +269,7 @@ const PropertiesModal = ({
   const handleOwnersSelectValue = () => {
     const parsedOwners = (owners || []).map((owner: Owner) => ({
       value: owner.id,
-      label: getOwnerName(owner),
+      label: getOwnerDisplayName(owner),
     }));
     return parsedOwners;
   };

--- a/superset-frontend/src/pages/DashboardList/index.tsx
+++ b/superset-frontend/src/pages/DashboardList/index.tsx
@@ -30,6 +30,7 @@ import rison from 'rison';
 import {
   createFetchRelated,
   createErrorHandler,
+  createFetchRelatedFormatted,
   handleDashboardDelete,
 } from 'src/views/CRUD/utils';
 import { useListViewResource, useFavoriteStatus } from 'src/views/CRUD/hooks';
@@ -90,6 +91,7 @@ interface DashboardListProps {
     userId: string | number;
     firstName: string;
     lastName: string;
+    username?: string;
   };
 }
 
@@ -557,7 +559,7 @@ function DashboardList(props: DashboardListProps) {
         input: 'select',
         operator: FilterOperator.RelationManyMany,
         unfilteredLabel: t('All'),
-        fetchSelects: createFetchRelated(
+        fetchSelects: createFetchRelatedFormatted(
           'dashboard',
           'owners',
           createErrorHandler(errMsg =>
@@ -568,6 +570,10 @@ function DashboardList(props: DashboardListProps) {
               ),
             ),
           ),
+          (data: { text: string; value: string | number; extra?: any }) =>
+            data.extra?.username
+              ? `${data.text} (${data.extra.username})`
+              : data.text,
           props.user,
         ),
         paginate: true,

--- a/superset-frontend/src/pages/DashboardList/index.tsx
+++ b/superset-frontend/src/pages/DashboardList/index.tsx
@@ -90,7 +90,6 @@ interface DashboardListProps {
     userId: string | number;
     firstName: string;
     lastName: string;
-    username?: string;
   };
 }
 

--- a/superset-frontend/src/pages/DashboardList/index.tsx
+++ b/superset-frontend/src/pages/DashboardList/index.tsx
@@ -30,7 +30,6 @@ import rison from 'rison';
 import {
   createFetchRelated,
   createErrorHandler,
-  createFetchRelatedFormatted,
   handleDashboardDelete,
 } from 'src/views/CRUD/utils';
 import { useListViewResource, useFavoriteStatus } from 'src/views/CRUD/hooks';
@@ -559,7 +558,7 @@ function DashboardList(props: DashboardListProps) {
         input: 'select',
         operator: FilterOperator.RelationManyMany,
         unfilteredLabel: t('All'),
-        fetchSelects: createFetchRelatedFormatted(
+        fetchSelects: createFetchRelated(
           'dashboard',
           'owners',
           createErrorHandler(errMsg =>
@@ -570,10 +569,6 @@ function DashboardList(props: DashboardListProps) {
               ),
             ),
           ),
-          (data: { text: string; value: string | number; extra?: any }) =>
-            data.extra?.username
-              ? `${data.text} (${data.extra.username})`
-              : data.text,
           props.user,
         ),
         paginate: true,

--- a/superset-frontend/src/types/Owner.ts
+++ b/superset-frontend/src/types/Owner.ts
@@ -26,4 +26,5 @@ export default interface Owner {
   id: number;
   last_name?: string;
   full_name?: string;
+  username?: string;
 }

--- a/superset-frontend/src/utils/getOwnerName.ts
+++ b/superset-frontend/src/utils/getOwnerName.ts
@@ -24,3 +24,14 @@ export default function getOwnerName(owner?: Owner): string {
   }
   return owner.full_name || `${owner.first_name} ${owner.last_name}`;
 }
+
+export function getOwnerDisplayName(owner?: Owner): string {
+  if (!owner) {
+    return '';
+  }
+
+  if (owner.username) {
+    return `${getOwnerName(owner)} (${owner.username})`;
+  }
+  return getOwnerName(owner);
+}

--- a/superset-frontend/src/views/CRUD/utils.tsx
+++ b/superset-frontend/src/views/CRUD/utils.tsx
@@ -76,7 +76,12 @@ const createFetchResourceMethod =
     resource: string,
     relation: string,
     handleError: (error: Response) => void,
-    user?: { userId: string | number; firstName: string; lastName: string },
+    user?: {
+      userId: string | number;
+      firstName: string;
+      lastName: string;
+      username: string;
+    },
   ) =>
   async (filterValue = '', page: number, pageSize: number) => {
     const resourceEndpoint = `/api/v1/${resource}/${method}/${relation}`;
@@ -94,6 +99,7 @@ const createFetchResourceMethod =
       ? {
           label: `${user.firstName} ${user.lastName}`,
           value: user.userId,
+          username: user.username,
         }
       : undefined;
 
@@ -104,7 +110,8 @@ const createFetchResourceMethod =
         if (
           loggedUser &&
           value === loggedUser.value &&
-          text === loggedUser.label
+          (text === loggedUser.label ||
+            text === `${loggedUser.label} (${loggedUser.username})`)
         ) {
           fetchedLoggedUser = true;
         } else {

--- a/superset-frontend/src/views/CRUD/utils.tsx
+++ b/superset-frontend/src/views/CRUD/utils.tsx
@@ -195,8 +195,6 @@ const createFetchResourceMethodFormatted =
       data.unshift(loggedUser);
     }
 
-    console.log(data);
-
     return {
       data,
       totalCount: json?.count,

--- a/superset-frontend/src/views/CRUD/utils.tsx
+++ b/superset-frontend/src/views/CRUD/utils.tsx
@@ -125,6 +125,84 @@ const createFetchResourceMethod =
     };
   };
 
+const createFetchResourceMethodFormatted =
+  (method: string) =>
+  (
+    resource: string,
+    relation: string,
+    handleError: (error: Response) => void,
+    handleLabelFormatting: (data: {
+      text: string;
+      value: string | number;
+      extra?: any;
+    }) => string,
+    user?: {
+      userId: string | number;
+      firstName: string;
+      lastName: string;
+      username?: string;
+    },
+  ) =>
+  async (filterValue = '', page: number, pageSize: number) => {
+    const resourceEndpoint = `/api/v1/${resource}/${method}/${relation}`;
+    const queryParams = rison.encode_uri({
+      filter: filterValue,
+      page,
+      page_size: pageSize,
+    });
+    const { json = {} } = await SupersetClient.get({
+      endpoint: `${resourceEndpoint}?q=${queryParams}`,
+    });
+
+    let fetchedLoggedUser = false;
+    const loggedUser = user
+      ? {
+          label: `${user.firstName} ${user.lastName}`,
+          value: user.userId,
+        }
+      : undefined;
+
+    const data: { label: string; value: string | number }[] = [];
+    json?.result
+      ?.filter(({ text }: { text: string }) => text.trim().length > 0)
+      .forEach(
+        ({
+          text,
+          value,
+          extra,
+        }: {
+          text: string;
+          value: string | number;
+          extra?: any;
+        }) => {
+          if (
+            loggedUser &&
+            value === loggedUser.value &&
+            text === loggedUser.label
+          ) {
+            fetchedLoggedUser = true;
+            loggedUser.label = handleLabelFormatting({ text, value, extra });
+          } else {
+            data.push({
+              label: handleLabelFormatting({ text, value, extra }),
+              value,
+            });
+          }
+        },
+      );
+
+    if (loggedUser && (!filterValue || fetchedLoggedUser)) {
+      data.unshift(loggedUser);
+    }
+
+    console.log(data);
+
+    return {
+      data,
+      totalCount: json?.count,
+    };
+  };
+
 export const PAGE_SIZE = 5;
 const getParams = (filters?: Filter[], selectColumns?: string[]) => {
   const params = {
@@ -247,6 +325,8 @@ export const getRecentActivityObjs = (
 
 export const createFetchRelated = createFetchResourceMethod('related');
 export const createFetchDistinct = createFetchResourceMethod('distinct');
+export const createFetchRelatedFormatted =
+  createFetchResourceMethodFormatted('related');
 
 export function createErrorHandler(
   handleErrorFunc: (

--- a/superset-frontend/src/views/CRUD/utils.tsx
+++ b/superset-frontend/src/views/CRUD/utils.tsx
@@ -125,82 +125,6 @@ const createFetchResourceMethod =
     };
   };
 
-const createFetchResourceMethodFormatted =
-  (method: string) =>
-  (
-    resource: string,
-    relation: string,
-    handleError: (error: Response) => void,
-    handleLabelFormatting: (data: {
-      text: string;
-      value: string | number;
-      extra?: any;
-    }) => string,
-    user?: {
-      userId: string | number;
-      firstName: string;
-      lastName: string;
-      username?: string;
-    },
-  ) =>
-  async (filterValue = '', page: number, pageSize: number) => {
-    const resourceEndpoint = `/api/v1/${resource}/${method}/${relation}`;
-    const queryParams = rison.encode_uri({
-      filter: filterValue,
-      page,
-      page_size: pageSize,
-    });
-    const { json = {} } = await SupersetClient.get({
-      endpoint: `${resourceEndpoint}?q=${queryParams}`,
-    });
-
-    let fetchedLoggedUser = false;
-    const loggedUser = user
-      ? {
-          label: `${user.firstName} ${user.lastName}`,
-          value: user.userId,
-        }
-      : undefined;
-
-    const data: { label: string; value: string | number }[] = [];
-    json?.result
-      ?.filter(({ text }: { text: string }) => text.trim().length > 0)
-      .forEach(
-        ({
-          text,
-          value,
-          extra,
-        }: {
-          text: string;
-          value: string | number;
-          extra?: any;
-        }) => {
-          if (
-            loggedUser &&
-            value === loggedUser.value &&
-            text === loggedUser.label
-          ) {
-            fetchedLoggedUser = true;
-            loggedUser.label = handleLabelFormatting({ text, value, extra });
-          } else {
-            data.push({
-              label: handleLabelFormatting({ text, value, extra }),
-              value,
-            });
-          }
-        },
-      );
-
-    if (loggedUser && (!filterValue || fetchedLoggedUser)) {
-      data.unshift(loggedUser);
-    }
-
-    return {
-      data,
-      totalCount: json?.count,
-    };
-  };
-
 export const PAGE_SIZE = 5;
 const getParams = (filters?: Filter[], selectColumns?: string[]) => {
   const params = {
@@ -323,8 +247,6 @@ export const getRecentActivityObjs = (
 
 export const createFetchRelated = createFetchResourceMethod('related');
 export const createFetchDistinct = createFetchResourceMethod('distinct');
-export const createFetchRelatedFormatted =
-  createFetchResourceMethodFormatted('related');
 
 export function createErrorHandler(
   handleErrorFunc: (

--- a/superset/dashboards/schemas.py
+++ b/superset/dashboards/schemas.py
@@ -206,7 +206,7 @@ class DashboardGetResponseSchema(Schema):
     changed_on = fields.DateTime()
     created_by = fields.Nested(UserSchema(exclude=["username"]))
     charts = fields.List(fields.String(metadata={"description": charts_description}))
-    owners = fields.List(fields.Nested(UserSchema(exclude=["username"])))
+    owners = fields.List(fields.Nested(UserSchema))
     roles = fields.List(fields.Nested(RolesSchema))
     tags = fields.Nested(TagSchema, many=True)
     changed_on_humanized = fields.String(data_key="changed_on_delta_humanized")

--- a/superset/views/base_api.py
+++ b/superset/views/base_api.py
@@ -300,7 +300,7 @@ class BaseSupersetModelRestApi(BaseSupersetApiMixin, ModelRestApi):
         }
     """
 
-    extra_fields_rel_fields: dict[str, list[str]] = {"owners": ["email", "active"]}
+    extra_fields_rel_fields: dict[str, list[str]] = {"owners": ["email", "active", "username"]}
     """
     Declare extra fields for the representation of the Model object::
 

--- a/superset/views/base_api.py
+++ b/superset/views/base_api.py
@@ -377,6 +377,9 @@ class BaseSupersetModelRestApi(BaseSupersetApiMixin, ModelRestApi):
         return filters
 
     def _get_text_for_model(self, model: Model, column_name: str) -> str:
+        # Special case for owners, we want to return the full name and username
+        if column_name == "owners":
+            return f"{model.first_name} {model.last_name} ({model.username})"
         if column_name in self.text_field_rel_fields:
             model_column_name = self.text_field_rel_fields.get(column_name)
             if model_column_name:


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Display the user's username in the dashboard's owner filter and the dashboard properties access field/dropdown. This helps us distinguish users with the same name, and allows us to search by username.

The api/v1/dashboard/related/owners endpoint was already returning the correct results when filtering by username, but the component filters out the results because the displayed name doesn't actually include the text filter.



### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
